### PR TITLE
enable to use 'shell' option

### DIFF
--- a/lib/vagrant-itamae/config.rb
+++ b/lib/vagrant-itamae/config.rb
@@ -5,12 +5,14 @@ module VagrantPlugins
       attr_accessor :yaml
       attr_accessor :sudo
       attr_accessor :recipes
+      attr_accessor :shell
 
       def initialize
         @recipes = UNSET_VALUE
         @json    = UNSET_VALUE
         @yaml    = UNSET_VALUE
         @sudo    = UNSET_VALUE
+        @shell   = UNSET_VALUE
       end
 
       def finalize!
@@ -19,6 +21,7 @@ module VagrantPlugins
 
         @json = nil if @json == UNSET_VALUE
         @yaml = nil if @yaml == UNSET_VALUE
+        @shell = nil if @shell == UNSET_VALUE
 
         @sudo = false if @sudo == UNSET_VALUE
       end

--- a/lib/vagrant-itamae/provisioner.rb
+++ b/lib/vagrant-itamae/provisioner.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
           node_json: config.json,
           node_yaml: config.yaml,
           sudo: config.sudo,
+          shell: config.shell,
           host: @machine.ssh_info[:host],
           port: @machine.ssh_info[:port],
           user: @machine.ssh_info[:username],


### PR DESCRIPTION
Itamae ( >= 1.4.4) has `--shell` option. This PR enables us to set the option from Vagrantfile.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/chiastolite/vagrant-itamae/8)
<!-- Reviewable:end -->
