### PR TITLE
add config.backend parameters for `itamae local`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Vagrant.configure('2') do |config|
     config.recipes = ['./recipe.rb']
 
     config.json = './node.json'
+
+    # switch backend (if you use 'local'. default "ssh")
+    config.backend = 'local'
   end
 end
 ```

--- a/lib/vagrant-itamae/config.rb
+++ b/lib/vagrant-itamae/config.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       attr_accessor :recipes
       attr_accessor :shell
       attr_accessor :log_level
+      attr_accessor :backend
 
       def initialize
         @recipes = UNSET_VALUE
@@ -17,6 +18,7 @@ module VagrantPlugins
         @sudo    = UNSET_VALUE
         @shell   = UNSET_VALUE
         @log_level = UNSET_VALUE
+        @backend  = UNSET_VALUE
       end
 
       def finalize!
@@ -28,6 +30,7 @@ module VagrantPlugins
         @shell = nil if @shell == UNSET_VALUE
 
         @sudo = false if @sudo == UNSET_VALUE
+        @backend = 'ssh' if @backend == UNSET_VALUE
 
         @log_level = ::Logger.const_get((@log_level == UNSET_VALUE ? :info : @log_level).upcase)
       end

--- a/lib/vagrant-itamae/provisioner.rb
+++ b/lib/vagrant-itamae/provisioner.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
         }
 
         ::Itamae.logger.level = config.log_level
-        ::Itamae::Runner.run(config.recipes, :ssh, options)
+        ::Itamae::Runner.run(config.recipes, config.backend.to_sym, options)
       end
     end
   end


### PR DESCRIPTION
# support "backend" option feature


It is always helped by the vagrant-itamae plug-in. However, I would like to execute ```itamae local```, but since I can not do it at present, I wanted to realize it with this pull request.

The sample Vagrantfile follows

```
  config.vm.provision :itamae do |config|
    config.recipes = ["./path/to/recipe.rb"]
    config.backend = 'local' # default parameter is 'ssh'
  end

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chiastolite/vagrant-itamae/10)
<!-- Reviewable:end -->
