### PR TITLE
::Itamae::Runner need options[:tmp_dir]

### DIFF
--- a/lib/vagrant-itamae/provisioner.rb
+++ b/lib/vagrant-itamae/provisioner.rb
@@ -12,7 +12,8 @@ module VagrantPlugins
           host: @machine.ssh_info[:host],
           port: @machine.ssh_info[:port],
           user: @machine.ssh_info[:username],
-          key:  @machine.ssh_info[:private_key_path][0]
+          key:  @machine.ssh_info[:private_key_path][0],
+          tmp_dir: "/tmp/itamae_tmp"
         }
 
         ::Itamae.logger.level = config.log_level


### PR DESCRIPTION
## What
fix for https://github.com/itamae-kitchen/itamae/commit/2e4ee5a30c158f2afb3b49bbbde606608b84d111
after itamae v1.12.0

## How
vagrant-itamae exec ::Itamae::Runner with options[:tmp_dir]

## Why
in vagrant provision using vagrant-itamae, these exception occured without this patch.
```
	  7: from /home/murasawa/.vagrant.d/gems/2.6.6/gems/vagrant-itamae-0.2.1/lib/vagrant-itamae/provisioner.rb:19:in `provision'
	  6: from /home/murasawa/.vagrant.d/gems/2.6.6/gems/itamae-1.12.1/lib/itamae/runner.rb:11:in `run'
	  5: from /home/murasawa/.vagrant.d/gems/2.6.6/gems/itamae-1.12.1/lib/itamae/runner.rb:11:in `new'
	  4: from /home/murasawa/.vagrant.d/gems/2.6.6/gems/itamae-1.12.1/lib/itamae/runner.rb:37:in `initialize'
	  3: from /home/murasawa/.vagrant.d/gems/2.6.6/gems/itamae-1.12.1/lib/itamae/backend.rb:49:in `run_command'
	  2: from /home/murasawa/.vagrant.d/gems/2.6.6/gems/itamae-1.12.1/lib/itamae/backend.rb:178:in `build_command'
	  1: from /home/murasawa/.vagrant.d/gems/2.6.6/gems/itamae-1.12.1/lib/itamae/backend.rb:178:in `map'
/home/murasawa/.vagrant.d/gems/2.6.6/gems/itamae-1.12.1/lib/itamae/backend.rb:179:in `block in build_command': undefined method `shellescape' for nil:NilClass (NoMethodError)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chiastolite/vagrant-itamae/11)
<!-- Reviewable:end -->
